### PR TITLE
Add `JSON.Writer`.

### DIFF
--- a/manifest.savi
+++ b/manifest.savi
@@ -1,6 +1,9 @@
 :manifest lib JSON
   :sources "src/*.savi"
 
+  :dependency ByteStream v0
+    :from "github:savi-lang/ByteStream"
+
 :manifest bin "spec"
   :copies JSON
   :sources "spec/*.savi"

--- a/spec/JSON.Writer.Spec.savi
+++ b/spec/JSON.Writer.Spec.savi
@@ -1,0 +1,115 @@
+:class _WriterExampleClass
+  :var name String
+  :var admin (Bool | None)
+  :new (@name, admin (Bool | None) = None)
+    @admin = admin // TODO: remove this intermediate variable
+
+  :fun trace_data(trace TraceData.Observer) None
+    trace.object(identity_digest_of @) -> (
+      trace.property("name", @name)
+      try trace.property("admin", @admin.not!(None))
+    )
+
+:class JSON.Writer.Spec
+  :is Spec
+  :const describes: "JSON.Writer"
+
+  :it "writes JSON"
+    streams = ByteStream.Pair.new
+    write = JSON.Writer.new(streams.write)
+
+    write.array -> (write |
+      write.child -> (write |
+        write.object -> (write |
+          write.string("name", "Alice")
+          write.bool("admin", True)
+        )
+      )
+      write.child -> (write |
+        write.object -> (write |
+          write.string("name", "Bob")
+        )
+      )
+      write.child -> (write |
+        write.object -> (write |
+          write.string("name", "Cyril")
+          write.bool("admin", False)
+        )
+      )
+    )
+
+    assert no_error: streams.write.flush!
+    assert: streams.read.extract_all.as_string ==
+      "[\(
+      ){\"name\":\"Alice\",\"admin\":true},\(
+      ){\"name\":\"Bob\"},\(
+      ){\"name\":\"Cyril\",\"admin\":false}\(
+      )]"
+
+  :it "writes pretty JSON"
+    streams = ByteStream.Pair.new
+    write = JSON.Writer.new_pretty(streams.write)
+
+    write.array -> (write |
+      write.child -> (write |
+        write.object -> (write |
+          write.string("name", "Alice")
+          write.bool("admin", True)
+        )
+      )
+      write.child -> (write |
+        write.object -> (write |
+          write.string("name", "Bob")
+        )
+      )
+      write.child -> (write |
+        write.object -> (write |
+          write.string("name", "Cyril")
+          write.bool("admin", False)
+        )
+      )
+    )
+
+    assert no_error: streams.write.flush!
+    assert: streams.read.extract_all.as_string == <<<
+      [
+        {
+          "name": "Alice",
+          "admin": true
+        },
+        {
+          "name": "Bob"
+        },
+        {
+          "name": "Cyril",
+          "admin": false
+        }
+      ]
+    >>>
+
+  :it "writes pretty JSON from traced data"
+    streams = ByteStream.Pair.new
+    write = JSON.Writer.new_pretty(streams.write)
+
+    alice = _WriterExampleClass.new("Alice", True)
+    bob   = _WriterExampleClass.new("Bob")
+    cyril = _WriterExampleClass.new("Cyril", False)
+
+    write.trace([alice, bob, cyril])
+
+    assert no_error: streams.write.flush!
+    assert: streams.read.extract_all.as_string == <<<
+      [
+        {
+          "name": "Alice",
+          "admin": true
+        },
+        {
+          "name": "Bob"
+        },
+        {
+          "name": "Cyril",
+          "admin": false
+        }
+      ]
+    >>>

--- a/spec/JSON.Writer.Spec.savi
+++ b/spec/JSON.Writer.Spec.savi
@@ -39,12 +39,13 @@
     )
 
     assert no_error: streams.write.flush!
-    assert: streams.read.extract_all.as_string ==
-      "[\(
-      ){\"name\":\"Alice\",\"admin\":true},\(
-      ){\"name\":\"Bob\"},\(
-      ){\"name\":\"Cyril\",\"admin\":false}\(
-      )]"
+    assert: streams.read.extract_all.as_string == String.join([
+      <<<[>>>
+      <<<{"name":"Alice","admin":true},>>>
+      <<<{"name":"Bob"},>>>
+      <<<{"name":"Cyril","admin":false}>>>
+      <<<]>>>
+    ])
 
   :it "writes pretty JSON"
     streams = ByteStream.Pair.new
@@ -112,4 +113,48 @@
           "admin": false
         }
       ]
+    >>>
+
+  :it "writes every traceable primitive data type"
+    streams = ByteStream.Pair.new
+    trace = JSON.Writer.TraceData.Observer.new(streams.write)
+
+    trace.array(0) -> (
+      trace.array_element(None)
+      trace.array_element(True)
+      trace.array_element(U8[8])
+      trace.array_element(U16[16])
+      trace.array_element(U32[32])
+      trace.array_element(U64[64])
+      trace.array_element(I8[-8])
+      trace.array_element(I16[-16])
+      trace.array_element(I32[-32])
+      trace.array_element(I64[-64])
+      trace.array_element(F32[32.5])
+      trace.array_element(F64[64.5])
+      trace.array_element(b"some bytes")
+      trace.array_element("some string")
+    )
+
+    assert no_error: streams.write.flush!
+    assert: streams.read.extract_all.as_string == <<<
+      [null,true,8,16,32,64,-8,-16,-32,-64,32.5,64.5,"some bytes","some string"]
+    >>>
+
+  :it "writes NaN, Infinity, and -Infinity values as null"
+    streams = ByteStream.Pair.new
+    trace = JSON.Writer.TraceData.Observer.new(streams.write)
+
+    trace.array(0) -> (
+      trace.array_element(F32.nan)
+      trace.array_element(F32.infinity)
+      trace.array_element(F32.neg_infinity)
+      trace.array_element(F64.nan)
+      trace.array_element(F64.infinity)
+      trace.array_element(F64.neg_infinity)
+    )
+
+    assert no_error: streams.write.flush!
+    assert: streams.read.extract_all.as_string == <<<
+      [null,null,null,null,null,null]
     >>>

--- a/spec/Main.savi
+++ b/spec/Main.savi
@@ -3,4 +3,5 @@
     Spec.Process.run(env, [
       Spec.Run(JSON.Parser.Spec).new(env)
       Spec.Run(JSON.Reader.Spec).new(env)
+      Spec.Run(JSON.Writer.Spec).new(env)
     ])

--- a/src/JSON.Writer.savi
+++ b/src/JSON.Writer.savi
@@ -3,10 +3,10 @@
   :new _new(@_write)
 
   :new (stream)
-    @_write = _Writer._new(stream)
+    @_write = _Writer.new(stream)
 
   :new new_pretty(stream, indent = 2)
-    @_write = _Writer._new(stream)
+    @_write = _Writer.new(stream)
     @_write._should_newline = True
     @_write._indent_spaces = indent
 
@@ -80,7 +80,7 @@
   :var _should_newline: False
   :var _is_first_in_collection: False
 
-  :new _new(@_stream)
+  :new new(@_stream)
 
   :fun _should_indent_with_tab: @_indent_spaces == @_indent_spaces.max_value
 
@@ -157,19 +157,42 @@
   :fun ref primitive_bool(value Bool) None
     @_stream << if value (b"true" | b"false")
 
-  :fun ref primitive_u64(value U64) None: @primitive_none // TODO
-  :fun ref primitive_u32(value U32) None: @primitive_none // TODO
-  :fun ref primitive_u16(value U16) None: @primitive_none // TODO
-  :fun ref primitive_u8(value U8) None: @primitive_none // TODO
-  :fun ref primitive_i64(value I64) None: @primitive_none // TODO
-  :fun ref primitive_i32(value I32) None: @primitive_none // TODO
-  :fun ref primitive_i16(value I16) None: @primitive_none // TODO
-  :fun ref primitive_i8(value I8) None: @primitive_none // TODO
-  :fun ref primitive_f64(value F64) None: @primitive_none // TODO
-  :fun ref primitive_f32(value F32) None: @primitive_none // TODO
+  :fun ref primitive_u64(value U64) None
+    @_stream << "\(value)".as_bytes // TODO: more efficient
 
-  :fun ref primitive_name(value String'box) None: @primitive_string(value)
-  :fun ref primitive_bytes(value Bytes'box) None: @primitive_string(value.clone.as_string) // TODO: more efficient
+  :fun ref primitive_u32(value U32) None
+    @_stream << "\(value)".as_bytes // TODO: more efficient
+
+  :fun ref primitive_u16(value U16) None
+    @_stream << "\(value)".as_bytes // TODO: more efficient
+
+  :fun ref primitive_u8(value U8) None
+    @_stream << "\(value)".as_bytes // TODO: more efficient
+
+  :fun ref primitive_i64(value I64) None
+    @_stream << "\(value)".as_bytes // TODO: more efficient
+
+  :fun ref primitive_i32(value I32) None
+    @_stream << "\(value)".as_bytes // TODO: more efficient
+
+  :fun ref primitive_i16(value I16) None
+    @_stream << "\(value)".as_bytes // TODO: more efficient
+
+  :fun ref primitive_i8(value I8) None
+    @_stream << "\(value)".as_bytes // TODO: more efficient
+
+  :fun ref primitive_f64(value F64) None
+    @_stream << if value.is_finite ("\(value)".as_bytes | b"null") // TODO: more efficient
+
+  :fun ref primitive_f32(value F32) None
+    @_stream << if value.is_finite ("\(value)".as_bytes | b"null") // TODO: more efficient
+
+  :fun ref primitive_name(value String'box) None
+    @primitive_string(value)
+
+  :fun ref primitive_bytes(value Bytes'box) None
+    @primitive_string(value.clone.as_string) // TODO: more efficient
+
   :fun ref primitive_string(value String'box) None
     @_stream.push('"')
     value.each_char_with_index_and_width -> (char, index, width |

--- a/src/JSON.Writer.savi
+++ b/src/JSON.Writer.savi
@@ -1,0 +1,182 @@
+:struct JSON.Writer
+  :let _write _Writer
+  :new _new(@_write)
+
+  :new (stream)
+    @_write = _Writer._new(stream)
+
+  :new new_pretty(stream, indent = 2)
+    @_write = _Writer._new(stream)
+    @_write._should_newline = True
+    @_write._indent_spaces = indent
+
+  :fun ref object
+    :yields JSON.Writer.InObject for None // TODO: type checking to prevent yield interruption
+    @_write.object(0) -> (yield JSON.Writer.InObject._new(@_write))
+
+  :fun ref array
+    :yields JSON.Writer.InArray for None // TODO: type checking to prevent yield interruption
+    @_write.array(0) -> (yield JSON.Writer.InArray._new(@_write))
+
+  :fun ref trace(child TraceData)
+    child.trace_data(@_write)
+
+  :fun ref string(value): @_write.primitive_string(value)
+
+  :fun ref bool(value): @_write.primitive_bool(value)
+
+:struct JSON.Writer.InObject
+  :let _write _Writer
+  :new _new(@_write)
+
+  :fun ref child(key)
+    @_write._pre_item
+    @_write._key(key)
+    yield JSON.Writer._new(@_write)
+
+  :fun ref trace(key, child TraceData)
+    @_write._pre_item
+    @_write._key(key)
+    child.trace_data(@_write)
+
+  :fun ref string(key, value)
+    @_write._pre_item
+    @_write._key(key)
+    @_write.primitive_string(value)
+
+  :fun ref bool(key, value)
+    @_write._pre_item
+    @_write._key(key)
+    @_write.primitive_bool(value)
+
+:struct JSON.Writer.InArray
+  :let _write _Writer
+  :new _new(@_write)
+
+  :fun ref child
+    @_write._pre_item
+    yield JSON.Writer._new(@_write)
+
+  :fun ref trace(child TraceData)
+    @_write._pre_item
+    child.trace_data(@_write)
+
+  :fun ref string(value)
+    @_write._pre_item
+    @_write.primitive_string(value)
+
+  :fun ref bool(value)
+    @_write._pre_item
+    @_write.primitive_bool(value)
+
+:alias _Writer: JSON.Writer.TraceData.Observer
+
+:class JSON.Writer.TraceData.Observer
+  :is TraceData.Observer
+
+  :var _stream ByteStream.Writer
+  :var _current_depth USize: 0
+  :var _indent_spaces U8: 0
+  :var _should_newline: False
+  :var _is_first_in_collection: False
+
+  :new _new(@_stream)
+
+  :fun _should_indent_with_tab: @_indent_spaces == @_indent_spaces.max_value
+
+  :fun ref _newline_and_indent None
+    @_stream.push('\n')
+
+    if @_should_indent_with_tab (
+      @_stream.push('\t')
+    |
+      (@_indent_spaces.usize * @_current_depth.usize).times -> (
+        @_stream.push(' ')
+      )
+    )
+
+  :fun ref _pre_item None
+    if !@_is_first_in_collection @_stream.push(',')
+    @_is_first_in_collection = False
+
+    if @_should_newline (
+      @_newline_and_indent
+    |
+      if @_indent_spaces.is_nonzero @_stream.push(' ')
+    )
+
+  :fun ref _finish_collection None
+    if (@_should_newline && !@_is_first_in_collection) @_newline_and_indent
+
+  :fun ref _key(name String)
+    @primitive_string(name)
+    @_stream.push(':')
+    if (@_should_newline || @_indent_spaces.is_nonzero) @_stream.push(' ')
+
+  :fun ref object(recurse_id USize) None
+    :yields None for None // TODO: add a "without interruption" enforcement to the yield signature to ensure that the yield block isn't allowed to jump away.
+    // TODO: should we handle the recurse_id in some way?
+
+    @_stream.push('{')
+    @_current_depth += 1
+    prior_is_first_in_collection = @_is_first_in_collection <<= True
+
+    yield None
+
+    @_is_first_in_collection = prior_is_first_in_collection
+    @_current_depth -= 1
+    @_finish_collection, @_stream.push('}')
+
+  :fun ref property(name String, value TraceData) None
+    @_pre_item
+    @_key(name)
+    value.trace_data(@)
+
+  :fun ref array(recurse_id USize) None
+    :yields None for None // TODO: add a "without interruption" enforcement to the yield signature to ensure that the yield block isn't allowed to jump away.
+    // TODO: should we handle the recurse_id in some way?
+
+    @_stream.push('[')
+    @_current_depth += 1
+    prior_is_first_in_collection = @_is_first_in_collection <<= True
+
+    yield None
+
+    @_is_first_in_collection = prior_is_first_in_collection
+    @_current_depth -= 1
+    @_finish_collection, @_stream.push(']')
+
+  :fun ref array_element(value TraceData) None
+    @_pre_item
+
+    value.trace_data(@)
+
+  :fun ref primitive_none None
+    @_stream << b"null"
+
+  :fun ref primitive_bool(value Bool) None
+    @_stream << if value (b"true" | b"false")
+
+  :fun ref primitive_u64(value U64) None: @primitive_none // TODO
+  :fun ref primitive_u32(value U32) None: @primitive_none // TODO
+  :fun ref primitive_u16(value U16) None: @primitive_none // TODO
+  :fun ref primitive_u8(value U8) None: @primitive_none // TODO
+  :fun ref primitive_i64(value I64) None: @primitive_none // TODO
+  :fun ref primitive_i32(value I32) None: @primitive_none // TODO
+  :fun ref primitive_i16(value I16) None: @primitive_none // TODO
+  :fun ref primitive_i8(value I8) None: @primitive_none // TODO
+  :fun ref primitive_f64(value F64) None: @primitive_none // TODO
+  :fun ref primitive_f32(value F32) None: @primitive_none // TODO
+
+  :fun ref primitive_name(value String'box) None: @primitive_string(value)
+  :fun ref primitive_bytes(value Bytes'box) None: @primitive_string(value.clone.as_string) // TODO: more efficient
+  :fun ref primitive_string(value String'box) None
+    @_stream.push('"')
+    value.each_char_with_index_and_width -> (char, index, width |
+      case char == (
+      | '"'  | @_stream.push('\\'), @_stream.push('"')
+      | '\\' | @_stream.push('\\'), @_stream.push('\\')
+      | @_stream << "\(char.format.unicode)".as_bytes // TODO: more efficient
+      )
+    )
+    @_stream.push('"')


### PR DESCRIPTION
This class can be used directly by the caller to write arbitrary data, or can be used with the standard `TraceData.Observer` pattern to emit JSON for a type that conforms to the `TraceData` trait.