### PR TITLE
Add missing `JSON.Writer` methods for remaining JSON data types.

### DIFF
--- a/spec/JSON.Writer.Spec.savi
+++ b/spec/JSON.Writer.Spec.savi
@@ -88,6 +88,105 @@
       ]
     >>>
 
+  :it "writes every JSON primitive data type"
+    streams = ByteStream.Pair.new
+    write = JSON.Writer.new(streams.write)
+
+    write.null,       streams.write.push('\n')
+    write.bool(True), streams.write.push('\n')
+    write.u8(8),      streams.write.push('\n')
+    write.u16(16),    streams.write.push('\n')
+    write.u32(32),    streams.write.push('\n')
+    write.u64(64),    streams.write.push('\n')
+    write.i8(-8),     streams.write.push('\n')
+    write.i16(-16),   streams.write.push('\n')
+    write.i32(-32),   streams.write.push('\n')
+    write.i64(-64),   streams.write.push('\n')
+    write.f32(32.5), streams.write.push('\n')
+    write.f64(64.5), streams.write.push('\n')
+    write.string("some string")
+
+    assert no_error: streams.write.flush!
+    assert: streams.read.extract_all.as_string == <<<
+      null
+      true
+      8
+      16
+      32
+      64
+      -8
+      -16
+      -32
+      -64
+      32.5
+      64.5
+      "some string"
+    >>>
+
+  :it "writes every JSON primitive data type in an array"
+    streams = ByteStream.Pair.new
+    write = JSON.Writer.new(streams.write)
+
+    write.array -> (write |
+      write.null
+      write.bool(True)
+      write.u8(8)
+      write.u16(16)
+      write.u32(32)
+      write.u64(64)
+      write.i8(-8)
+      write.i16(-16)
+      write.i32(-32)
+      write.i64(-64)
+      write.f32(32.5)
+      write.f64(64.5)
+      write.string("some string")
+    )
+
+    assert no_error: streams.write.flush!
+    assert: streams.read.extract_all.as_string == <<<
+      [null,true,8,16,32,64,-8,-16,-32,-64,32.5,64.5,"some string"]
+    >>>
+
+  :it "writes every JSON primitive data type in an object"
+    streams = ByteStream.Pair.new
+    write = JSON.Writer.new_pretty(streams.write)
+
+    write.object -> (write |
+      write.null("A")
+      write.bool("B", True)
+      write.u8("C", 8)
+      write.u16("D", 16)
+      write.u32("E", 32)
+      write.u64("F", 64)
+      write.i8("G", -8)
+      write.i16("H", -16)
+      write.i32("I", -32)
+      write.i64("J", -64)
+      write.f32("K", 32.5)
+      write.f64("L", 64.5)
+      write.string("M", "some string")
+    )
+
+    assert no_error: streams.write.flush!
+    assert: streams.read.extract_all.as_string == <<<
+      {
+        "A": null,
+        "B": true,
+        "C": 8,
+        "D": 16,
+        "E": 32,
+        "F": 64,
+        "G": -8,
+        "H": -16,
+        "I": -32,
+        "J": -64,
+        "K": 32.5,
+        "L": 64.5,
+        "M": "some string"
+      }
+    >>>
+
   :it "writes pretty JSON from traced data"
     streams = ByteStream.Pair.new
     write = JSON.Writer.new_pretty(streams.write)

--- a/src/JSON.Writer.savi
+++ b/src/JSON.Writer.savi
@@ -21,9 +21,19 @@
   :fun ref trace(child TraceData)
     child.trace_data(@_write)
 
+  :fun ref null:          @_write.primitive_none
+  :fun ref bool(value):   @_write.primitive_bool(value)
+  :fun ref u8(value):     @_write.primitive_u8(value)
+  :fun ref u16(value):    @_write.primitive_u16(value)
+  :fun ref u32(value):    @_write.primitive_u32(value)
+  :fun ref u64(value):    @_write.primitive_u64(value)
+  :fun ref i8(value):     @_write.primitive_i8(value)
+  :fun ref i16(value):    @_write.primitive_i16(value)
+  :fun ref i32(value):    @_write.primitive_i32(value)
+  :fun ref i64(value):    @_write.primitive_i64(value)
+  :fun ref f32(value):    @_write.primitive_f32(value)
+  :fun ref f64(value):    @_write.primitive_f64(value)
   :fun ref string(value): @_write.primitive_string(value)
-
-  :fun ref bool(value): @_write.primitive_bool(value)
 
 :struct JSON.Writer.InObject
   :let _write _Writer
@@ -39,15 +49,19 @@
     @_write._key(key)
     child.trace_data(@_write)
 
-  :fun ref string(key, value)
-    @_write._pre_item
-    @_write._key(key)
-    @_write.primitive_string(value)
-
-  :fun ref bool(key, value)
-    @_write._pre_item
-    @_write._key(key)
-    @_write.primitive_bool(value)
+  :fun ref null(key):          @_write._pre_item, @_write._key(key), @_write.primitive_none
+  :fun ref bool(key, value):   @_write._pre_item, @_write._key(key), @_write.primitive_bool(value)
+  :fun ref u8(key, value):     @_write._pre_item, @_write._key(key), @_write.primitive_u8(value)
+  :fun ref u16(key, value):    @_write._pre_item, @_write._key(key), @_write.primitive_u16(value)
+  :fun ref u32(key, value):    @_write._pre_item, @_write._key(key), @_write.primitive_u32(value)
+  :fun ref u64(key, value):    @_write._pre_item, @_write._key(key), @_write.primitive_u64(value)
+  :fun ref i8(key, value):     @_write._pre_item, @_write._key(key), @_write.primitive_i8(value)
+  :fun ref i16(key, value):    @_write._pre_item, @_write._key(key), @_write.primitive_i16(value)
+  :fun ref i32(key, value):    @_write._pre_item, @_write._key(key), @_write.primitive_i32(value)
+  :fun ref i64(key, value):    @_write._pre_item, @_write._key(key), @_write.primitive_i64(value)
+  :fun ref f32(key, value):    @_write._pre_item, @_write._key(key), @_write.primitive_f32(value)
+  :fun ref f64(key, value):    @_write._pre_item, @_write._key(key), @_write.primitive_f64(value)
+  :fun ref string(key, value): @_write._pre_item, @_write._key(key), @_write.primitive_string(value)
 
 :struct JSON.Writer.InArray
   :let _write _Writer
@@ -61,13 +75,19 @@
     @_write._pre_item
     child.trace_data(@_write)
 
-  :fun ref string(value)
-    @_write._pre_item
-    @_write.primitive_string(value)
-
-  :fun ref bool(value)
-    @_write._pre_item
-    @_write.primitive_bool(value)
+  :fun ref null:          @_write._pre_item, @_write.primitive_none
+  :fun ref bool(value):   @_write._pre_item, @_write.primitive_bool(value)
+  :fun ref u8(value):     @_write._pre_item, @_write.primitive_u8(value)
+  :fun ref u16(value):    @_write._pre_item, @_write.primitive_u16(value)
+  :fun ref u32(value):    @_write._pre_item, @_write.primitive_u32(value)
+  :fun ref u64(value):    @_write._pre_item, @_write.primitive_u64(value)
+  :fun ref i8(value):     @_write._pre_item, @_write.primitive_i8(value)
+  :fun ref i16(value):    @_write._pre_item, @_write.primitive_i16(value)
+  :fun ref i32(value):    @_write._pre_item, @_write.primitive_i32(value)
+  :fun ref i64(value):    @_write._pre_item, @_write.primitive_i64(value)
+  :fun ref f32(value):    @_write._pre_item, @_write.primitive_f32(value)
+  :fun ref f64(value):    @_write._pre_item, @_write.primitive_f64(value)
+  :fun ref string(value): @_write._pre_item, @_write.primitive_string(value)
 
 :alias _Writer: JSON.Writer.TraceData.Observer
 


### PR DESCRIPTION
I neglected to add these in the previous PR. Whoops.