### PR TITLE
Fix JSON.Parser to have an explicit error type.

### DIFF
--- a/src/JSON.Parser.savi
+++ b/src/JSON.Parser.savi
@@ -68,6 +68,7 @@
 
   :fun ref _parse_data!
     :yields JSON.Token for None
+    :errors None
     @_skip_whitespace
     @_pre_token
     peeked = @_peek!


### PR DESCRIPTION
Prior to this commit, the library wasn't compiling with the latest version of Savi because latest Savi allows for error values with a designated type, but this function was self-recursive and thus couldn't confidently infer the error type.

This commit resolves the ambiguity by adding `:errors None`.